### PR TITLE
Ignore eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'react',
   ],
   rules: {
-
+    'arrow-parens': 0,
+    'react/prop-types': 0,
   },
 };


### PR DESCRIPTION
Ignored **arrow-parents** and **react/prop-types** eslint rules.